### PR TITLE
Add __isset magic method

### DIFF
--- a/src/Models/Concerns/HasAttributes.php
+++ b/src/Models/Concerns/HasAttributes.php
@@ -62,6 +62,18 @@ trait HasAttributes
     }
 
     /**
+     * Allow isset() calls for unknown variables
+     * 
+     * @param mixed $key
+     * @return bool
+     */
+    public function __isset($key)
+    {
+        $attr = $this->getAttribute($key);
+        return isset($attr);
+    }
+
+    /**
      * Synchronizes the models original attributes
      * with the model's current attributes.
      *


### PR DESCRIPTION
When doing custom pagination searches, it is handy to use isset() functions to see if ranges are set (members;range=0-499 vs members;range=0-*).  This simple __isset method should allow that to work.

I had to get the attribute first.  Then do the isset.  I think because it would create a loop otherwise.